### PR TITLE
Refactor device resolution logic in GAN and CTGAN models; update dataset selection in pipeline script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Dataset directory
+# Dataset and results directory
 data/
+results/
 *.csv
 *.zip
 

--- a/model/pytorch_cond_wgan.py
+++ b/model/pytorch_cond_wgan.py
@@ -17,11 +17,21 @@ from sklearn.cluster import KMeans
 
 
 # Utilities
-def get_device(prefer="mps"):
-    if prefer == "mps" and torch.backends.mps.is_available():
-        return "mps"
-    
-    return "cuda" if torch.cuda.is_available() else "cpu"
+def get_device(prefer: str | None = None) -> str:
+    order = []
+    if prefer in {"cuda", "mps", "cpu"}:
+        order.append(prefer)
+    for candidate in ("cuda", "mps", "cpu"):
+        if candidate not in order:
+            order.append(candidate)
+    for candidate in order:
+        if candidate == "cuda" and torch.cuda.is_available():
+            return "cuda"
+        if candidate == "mps" and torch.backends.mps.is_available():
+            return "mps"
+        if candidate == "cpu":
+            return "cpu"
+    return "cpu"
 
 
 def one_hot(indices: torch.Tensor, num_classes: int) -> torch.Tensor:
@@ -409,7 +419,7 @@ def oversample_with_cond_wgangp(
     seed: int = 42,
     n_clusters: int = 8,
     pac: int = 5,
-    device_prefer: str = "mps",
+    device_prefer: str | None = None,
 ):
     """
     Oversample minority class using cluster-conditional WGAN-GP + PacGAN.

--- a/model/pytorch_gan.py
+++ b/model/pytorch_gan.py
@@ -12,6 +12,22 @@ from torch.utils.data import DataLoader, TensorDataset
 import warnings
 warnings.filterwarnings('ignore')
 
+def resolve_device(prefer: str | None = None) -> str:
+    order = []
+    if prefer in {"cuda", "mps", "cpu"}:
+        order.append(prefer)
+    for candidate in ("cuda", "mps", "cpu"):
+        if candidate not in order:
+            order.append(candidate)
+    for candidate in order:
+        if candidate == "cuda" and torch.cuda.is_available():
+            return "cuda"
+        if candidate == "mps" and torch.backends.mps.is_available():
+            return "mps"
+        if candidate == "cpu":
+            return "cpu"
+    return "cpu"
+
 
 # Define PyTorch GAN components
 class Generator(nn.Module):
@@ -52,7 +68,7 @@ class Discriminator(nn.Module):
         return self.network(data)
 
 class GANOversampler:
-    def __init__(self, data_dim, noise_dim=100, hidden_dim=128, lr=0.0002, device='mps'):
+    def __init__(self, data_dim, noise_dim=100, hidden_dim=128, lr=0.0002, device='cpu'):
         self.device = device
         self.noise_dim = noise_dim
         self.data_dim = data_dim
@@ -179,6 +195,7 @@ def oversample_with_pytorch_gan(
     cache_path: str | None = None,
     cache_tag: str | None = None,
     seed: int = 42,
+    device_prefer: str | None = None,
 ):
     """
     Oversample minority class using Pytorch GAN.
@@ -263,7 +280,7 @@ def oversample_with_pytorch_gan(
             return X_balanced, y_balanced, [], []
 
     # Setup device
-    device = 'mps' if torch.backends.mps.is_available() else 'cpu'
+    device = resolve_device(device_prefer)
     print(f"Using device: {device}")
 
     # Initialize and train GAN oversampler

--- a/scripts/advance_pipeline.py
+++ b/scripts/advance_pipeline.py
@@ -40,7 +40,7 @@ except FileNotFoundError:
 
 # === DATASET SELECTION ===
 # Change this to switch datasets
-DATASET_NAME = '05_online_payment.csv' # or '01_creditcard.csv', '03_fraud_oracle.csv', '04_bank_account.csv', '05_online_payment.csv'
+DATASET_NAME = '03_fraud_oracle.csv' # or '01_creditcard.csv', '03_fraud_oracle.csv', '04_bank_account.csv', '05_online_payment.csv'
 DATA_ROOT = "/Users/rudyhendrawan/Projects/data"
 logger.info(f"Loading dataset: {DATASET_CONFIG[DATASET_NAME]['name']}")
 


### PR DESCRIPTION
This pull request refactors device selection logic across GAN-related modules to provide a more flexible and consistent way of specifying the preferred computation device (CUDA, MPS, or CPU) for PyTorch models. The device preference can now be set via function arguments, and the logic for resolving the best available device is unified across modules. Additionally, the default dataset in the pipeline script has been changed.

Device selection improvements:
* Introduced a `resolve_device` utility function in both `model/pytorch_ctgan.py` and `model/pytorch_gan.py` to determine the best available device based on user preference and hardware support. This replaces hardcoded device selection logic. [[1]](diffhunk://#diff-df1b15054ba04080d0a96eb140d31682f00c477b58e2597535bb943902e6e771R14-R29) [[2]](diffhunk://#diff-21de0083ee97894c8b56ea807f7b5345696ad26c218da247903361edbf9b4a48R15-R30)
* Refactored the `get_device` function in `model/pytorch_cond_wgan.py` to use a similar device resolution approach, now supporting an explicit device preference and falling back gracefully.

API and default behavior changes:
* Updated the constructors of `SimplifiedCTGAN` and `GANOversampler` to default to `'cpu'` instead of `'mps'`, and changed device setup in oversampling functions to use the new device resolution logic. [[1]](diffhunk://#diff-df1b15054ba04080d0a96eb140d31682f00c477b58e2597535bb943902e6e771L49-R65) [[2]](diffhunk://#diff-21de0083ee97894c8b56ea807f7b5345696ad26c218da247903361edbf9b4a48L55-R71) [[3]](diffhunk://#diff-df1b15054ba04080d0a96eb140d31682f00c477b58e2597535bb943902e6e771L291-R308) [[4]](diffhunk://#diff-21de0083ee97894c8b56ea807f7b5345696ad26c218da247903361edbf9b4a48L266-R283)
* Added a `device_prefer` parameter to the `oversample_with_ctgan`, `oversample_with_pytorch_gan`, and `oversample_with_cond_wgangp` functions, allowing callers to specify device preference. [[1]](diffhunk://#diff-df1b15054ba04080d0a96eb140d31682f00c477b58e2597535bb943902e6e771R222) [[2]](diffhunk://#diff-21de0083ee97894c8b56ea807f7b5345696ad26c218da247903361edbf9b4a48R198) [[3]](diffhunk://#diff-804c6df619c04df9a3686b370c57f731aa61361a528c0341914114082d72ea7dL412-R422)

Pipeline configuration:
* Changed the default dataset in `scripts/advance_pipeline.py` from `'05_online_payment.csv'` to `'03_fraud_oracle.csv'`.